### PR TITLE
update readme for adding IP and Port

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Java 17
 
 Open the configuration interface by clicking on the copyright label.
 ![img_6.png](img_6.png)
-Then input your pihole IP Address and API Token, and click Apply.
+Then input your pihole IP Address(10.10.10.1, or with port 10.10.10.1:888) and API Token, and click Apply.
+With Windows you can find the settings json in C:\users\YOUR USERNAME\PiHole Widget if the application is asking for you to configure it.
 
 ## Where to find the API TOKEN
 


### PR DESCRIPTION
Readme was missing that you can change the settings json if the application was asking you to configure first, also added description on how to do so with also adding the port if pihole is not hosted on port 80.